### PR TITLE
Add test to casetext

### DIFF
--- a/src/codelens.ts
+++ b/src/codelens.ts
@@ -4,7 +4,7 @@ import { TextCase } from './types';
 import { flatMap } from './utils';
 import { RunVitestCommand, DebugVitestCommand } from './vscode';
 
-const caseText = new Set(['it', 'describe']);
+const caseText = new Set(['it', 'describe','test']);
 
 function tryGetVitestTestCase(
     typescript: typeof ts,


### PR DESCRIPTION
`test` is interchangeable with `it` it would be nice if this plugin also support test.