### PR TITLE
feat: add support to monorepo and fix varius issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,5 +40,8 @@
     "package": "yarn build && yarn vsce package",
     "format:check": "prettier --config ./prettier.config.json --c ./src/**/*.ts",
     "format:write": "yarn format:check --write"
+  },
+  "dependencies": {
+    "find-up": "^5.0.0"
   }
 }

--- a/src/run.ts
+++ b/src/run.ts
@@ -12,9 +12,9 @@ function getCwd(testFile: string) {
     return path.dirname(configFilePath);
 }
 
-function buildVitestArgs({ caseName, casePath, sanitize = true }: { caseName: string, casePath: string, sanitize?: boolean }) {    
+function buildVitestArgs({ caseName, casePath, sanitize = true }: { caseName: string, casePath: string, sanitize?: boolean }) {
     let sanitizedCasePath = casePath;
-    if(sanitize) {
+    if (sanitize) {
         sanitizedCasePath = JSON.stringify(casePath);
         caseName = JSON.stringify(caseName);
     }
@@ -22,19 +22,32 @@ function buildVitestArgs({ caseName, casePath, sanitize = true }: { caseName: st
     const args = ['vitest', 'run', '-t', caseName, '--dir', sanitizedCasePath];
 
     const rootDir = getCwd(casePath);
-    if(rootDir) {
+    if (rootDir) {
         args.push('--root', rootDir);
     }
 
     return args;
 }
 
+let terminal: vscode.Terminal | undefined;
+
 export function runInTerminal(text: string, filename: string) {
     const casePath = path.dirname(filename);
-    const terminal = vscode.window.createTerminal(`vitest - ${text}`);
+    let terminalAlreadyExists = true;
+    if (!terminal || terminal.exitStatus) {
+        terminalAlreadyExists = false;
+        terminal?.dispose();
+        terminal = vscode.window.createTerminal(`vscode-vitest-runner`);
+    }
 
     const vitestArgs = buildVitestArgs({ caseName: text, casePath: casePath });
     const npxArgs = ['npx', ...vitestArgs];
+
+    if (terminalAlreadyExists) {
+        // CTRL-C to stop the previous run
+        terminal.sendText('\x03');
+    }
+
     terminal.sendText(npxArgs.join(' '), true);
     terminal.show();
 }

--- a/src/run.ts
+++ b/src/run.ts
@@ -19,7 +19,7 @@ function buildVitestArgs({ caseName, casePath, sanitize = true }: { caseName: st
         caseName = JSON.stringify(caseName);
     }
 
-    const args = ['vitest', 'run', '-t', caseName, '--dir', sanitizedCasePath];
+    const args = ['vitest', 'run', '-t', caseName, sanitizedCasePath];
 
     const rootDir = getCwd(casePath);
     if (rootDir) {
@@ -32,7 +32,6 @@ function buildVitestArgs({ caseName, casePath, sanitize = true }: { caseName: st
 let terminal: vscode.Terminal | undefined;
 
 export function runInTerminal(text: string, filename: string) {
-    const casePath = path.dirname(filename);
     let terminalAlreadyExists = true;
     if (!terminal || terminal.exitStatus) {
         terminalAlreadyExists = false;
@@ -40,7 +39,7 @@ export function runInTerminal(text: string, filename: string) {
         terminal = vscode.window.createTerminal(`vscode-vitest-runner`);
     }
 
-    const vitestArgs = buildVitestArgs({ caseName: text, casePath: casePath });
+    const vitestArgs = buildVitestArgs({ caseName: text, casePath: filename });
     const npxArgs = ['npx', ...vitestArgs];
 
     if (terminalAlreadyExists) {
@@ -60,7 +59,7 @@ function buildDebugConfig(
         name: 'Debug vitest case',
         request: 'launch',
         runtimeArgs: buildVitestArgs({ caseName: text, casePath: casePath, sanitize: false }),
-        cwd: getCwd(casePath) || casePath,
+        cwd: getCwd(casePath) || path.dirname(casePath),
         runtimeExecutable: 'npx',
         skipFiles: ['<node_internals>/**'],
         type: 'pwa-node',
@@ -70,7 +69,6 @@ function buildDebugConfig(
 }
 
 export function debugInTermial(text: string, filename: string) {
-    const casePath = path.dirname(filename);
-    const config = buildDebugConfig(casePath, text);
+    const config = buildDebugConfig(filename, text);
     vscode.debug.startDebugging(undefined, config);
 }

--- a/src/run.ts
+++ b/src/run.ts
@@ -1,39 +1,53 @@
 import * as vscode from 'vscode';
 import * as path from 'path';
+import * as findUp from 'find-up';
+import { configFiles } from './vitest-config-files';
 
-function buildVitestArgs(text: string) {
-    return ['vitest', 'run', '-t', text];
+function getCwd(testFile: string) {
+    const configFilePath = findUp.sync(configFiles, { cwd: testFile });
+
+    if (!configFilePath) {
+        return;
+    }
+    return path.dirname(configFilePath);
 }
 
-function buildCdArgs(path: string) {
-    return ['cd', path];
+function buildVitestArgs({ caseName, casePath, sanitize = true }: { caseName: string, casePath: string, sanitize?: boolean }) {    
+    let sanitizedCasePath = casePath;
+    if(sanitize) {
+        sanitizedCasePath = JSON.stringify(casePath);
+        caseName = JSON.stringify(caseName);
+    }
+
+    const args = ['vitest', 'run', '-t', caseName, '--dir', sanitizedCasePath];
+
+    const rootDir = getCwd(casePath);
+    if(rootDir) {
+        args.push('--root', rootDir);
+    }
+
+    return args;
 }
 
 export function runInTerminal(text: string, filename: string) {
     const casePath = path.dirname(filename);
     const terminal = vscode.window.createTerminal(`vitest - ${text}`);
 
-    const casePathStr = JSON.stringify(casePath);
-    const caseNameStr = JSON.stringify(text);
-
-    const cdArgs = buildCdArgs(casePathStr);
-    terminal.sendText(cdArgs.join(' '), true);
-
-    const vitestArgs = buildVitestArgs(caseNameStr);
+    const vitestArgs = buildVitestArgs({ caseName: text, casePath: casePath });
     const npxArgs = ['npx', ...vitestArgs];
     terminal.sendText(npxArgs.join(' '), true);
     terminal.show();
 }
 
 function buildDebugConfig(
-    cwd: string,
+    casePath: string,
     text: string
 ): vscode.DebugConfiguration {
     return {
         name: 'Debug vitest case',
         request: 'launch',
-        runtimeArgs: buildVitestArgs(text),
-        cwd,
+        runtimeArgs: buildVitestArgs({ caseName: text, casePath: casePath, sanitize: false }),
+        cwd: getCwd(casePath) || casePath,
         runtimeExecutable: 'npx',
         skipFiles: ['<node_internals>/**'],
         type: 'pwa-node',

--- a/src/vitest-config-files.ts
+++ b/src/vitest-config-files.ts
@@ -1,0 +1,16 @@
+
+const CONFIG_NAMES = [
+  'vitest.config',
+  'vite.config',
+]
+
+const CONFIG_EXTENSIONS = [
+  '.ts',
+  '.mts',
+  '.cts',
+  '.js',
+  '.mjs',
+  '.cjs',
+]
+
+export const configFiles = CONFIG_NAMES.reduce((arr, name) => arr.concat(CONFIG_EXTENSIONS.map(ext => name + ext)), [] as string[]);


### PR DESCRIPTION
# Given that this project is not maintained anymore I've created a new extension that actually works - [here](https://marketplace.visualstudio.com/items?itemName=rluvaton.vscode-vitest)


-----

3 things this PR fixes:

## Monorepo support
add support to Monorepo by looking up the nearest vitest config

inside a monorepo we have vitest config in the application folder and not the folder where the package json exists

```
- package.json
- apps/
  - app1/
     - vitest.config.ts
     - src/
     - tests/
```

Fix #7

## React scripts fix
don't `cd` to the current dir name as some places rely on the cwd

like this:
https://github.com/facebook/create-react-app/blob/0a827f69ab0d2ee3871ba9b71350031d8a81b7ae/packages/react-scripts/config/paths.js#L15-L30

it will try to read the package json in the cwd

## Reuse existing terminal

this will reuse the existing terminal fix #8 