### PR TITLE
fix: provide file path to avoid seeking skipped files

### DIFF
--- a/src/run.ts
+++ b/src/run.ts
@@ -1,8 +1,8 @@
 import * as vscode from 'vscode';
 import * as path from 'path';
 
-function buildVitestArgs(text: string) {
-    return ['vitest', 'run', '-t', text];
+function buildVitestArgs(text: string, path: string) {
+    return ['vitest', 'run', '-t', text, path];
 }
 
 function buildCdArgs(path: string) {
@@ -19,7 +19,7 @@ export function runInTerminal(text: string, filename: string) {
     const cdArgs = buildCdArgs(casePathStr);
     terminal.sendText(cdArgs.join(' '), true);
 
-    const vitestArgs = buildVitestArgs(caseNameStr);
+    const vitestArgs = buildVitestArgs(caseNameStr, casePathStr);
     const npxArgs = ['npx', ...vitestArgs];
     terminal.sendText(npxArgs.join(' '), true);
     terminal.show();
@@ -32,7 +32,7 @@ function buildDebugConfig(
     return {
         name: 'Debug vitest case',
         request: 'launch',
-        runtimeArgs: buildVitestArgs(text),
+        runtimeArgs: buildVitestArgs(text, cwd),
         cwd,
         runtimeExecutable: 'npx',
         skipFiles: ['<node_internals>/**'],


### PR DESCRIPTION
## Description 

Adds the `path` to the `npx vitest -t <testPattern> <path>`. The benefit of this is now when a project/library has many different test files, it will skip seeking through all the tests to skip. And instead just look at the file in question.

Before:
https://www.loom.com/share/24bee8d6dc8a4a0a8b9fd5ddb2d1beef

After:
https://www.loom.com/share/7e49382b5faf47f8a13115bb0039631a